### PR TITLE
Fixed error `Missing 'paragraph' from library` when compiling.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,5 +3,6 @@ version=0.0.1
 author=Ivo Pullens
 maintainer=Ivo Pullens
 sentence=AC101 audio codec driver library for Arduino
+paragraph=AC101 audio codec driver library for Arduino
 category=Device Control
 url=https://github.com/Yveaux/AC101


### PR DESCRIPTION
library.properties expects a `paragraph` section which was missing.