### PR TITLE
Implement of TwoWire Object

### DIFF
--- a/examples/ESP32AudioKit/ESP32AudioKit.ino
+++ b/examples/ESP32AudioKit/ESP32AudioKit.ino
@@ -25,6 +25,10 @@
 #include "AudioGeneratorRTTTL.h"
 #include "AudioOutputI2S.h"
 #include "AC101.h"
+#include "Wire.h"
+
+TwoWire i2cBusOne = TwoWire(0);
+static AC101 ac(i2cBusOne);
 
 const char song[] PROGMEM = 
 "Batman:d=8,o=5,b=180:d,d,c#,c#,c,c,c#,c#,d,d,c#,c#,c,c,c#,c#,d,d#,c,c#,c,c,c#,c#,f,p,4f";
@@ -48,17 +52,15 @@ AudioOutputI2S *out;
 #define PIN_VOL_UP                  (18)      // KEY 5
 #define PIN_VOL_DOWN                (5)       // KEY 6
 
-static AC101 ac;
-
 static uint8_t volume = 5;
 const uint8_t volume_step = 2;
 
 void setup()
 {
 	Serial.begin(115200);
-
+  i2cBusOne.begin(IIC_DATA, IIC_CLK, 40000);
 	Serial.printf("Connect to AC101 codec... ");
-	while (not ac.begin(IIC_DATA, IIC_CLK))
+	while (not ac.begin())
 	{
 		Serial.printf("Failed!\n");
 		delay(1000);
@@ -148,4 +150,3 @@ void loop()
 		ac.SetVolumeHeadphone(volume);
 	}
 }
-

--- a/src/AC101.cpp
+++ b/src/AC101.cpp
@@ -137,37 +137,35 @@ const uint8_t regs[] = {
 
 bool AC101::WriteReg(uint8_t reg, uint16_t val)
 {
-	Wire.beginTransmission(AC101_ADDR);
-	Wire.write(reg);
-	Wire.write(uint8_t((val >> 8) & 0xff));
-	Wire.write(uint8_t(val & 0xff));
-	return 0 == Wire.endTransmission(true);
+	_TwoWireInstance.beginTransmission(AC101_ADDR);
+	_TwoWireInstance.write(reg);
+	_TwoWireInstance.write(uint8_t((val >> 8) & 0xff));
+	_TwoWireInstance.write(uint8_t(val & 0xff));
+	return 0 == _TwoWireInstance.endTransmission(true);
 }
 
 uint16_t AC101::ReadReg(uint8_t reg)
 {
-	Wire.beginTransmission(AC101_ADDR);
-	Wire.write(reg);
-	Wire.endTransmission(false);
+	_TwoWireInstance.beginTransmission(AC101_ADDR);
+	_TwoWireInstance.write(reg);
+	_TwoWireInstance.endTransmission(false);
 
 	uint16_t val = 0u;
-	if (2 == Wire.requestFrom(uint16_t(AC101_ADDR), uint8_t(2), true))
+	if (2 == _TwoWireInstance.requestFrom(uint16_t(AC101_ADDR), uint8_t(2), true))
 	{
-		val = uint16_t(Wire.read() << 8) + uint16_t(Wire.read());
+		val = uint16_t(_TwoWireInstance.read() << 8) + uint16_t(_TwoWireInstance.read());
 	}
-	Wire.endTransmission(false);
+	_TwoWireInstance.endTransmission(false);
 
 	return val;
 }
 
-AC101::AC101()
+AC101::AC101( TwoWire & TwoWireInstance ) : _TwoWireInstance(TwoWireInstance)
 {
 }
 
-bool AC101::begin(int sda, int scl, uint32_t frequency)
+bool AC101::begin()
 {
-	bool ok = Wire.begin(sda, scl, frequency);
-
 	// Reset all registers, readback default as sanity check
 	ok &= WriteReg(CHIP_AUDIO_RS, 0x123);
 	delay(100);

--- a/src/AC101.cpp
+++ b/src/AC101.cpp
@@ -137,31 +137,32 @@ const uint8_t regs[] = {
 
 bool AC101::WriteReg(uint8_t reg, uint16_t val)
 {
-	_TwoWireInstance.beginTransmission(AC101_ADDR);
-	_TwoWireInstance.write(reg);
-	_TwoWireInstance.write(uint8_t((val >> 8) & 0xff));
-	_TwoWireInstance.write(uint8_t(val & 0xff));
-	return 0 == _TwoWireInstance.endTransmission(true);
+	_TwoWireInstance->beginTransmission(AC101_ADDR);
+	_TwoWireInstance->write(reg);
+	_TwoWireInstance->write(uint8_t((val >> 8) & 0xff));
+	_TwoWireInstance->write(uint8_t(val & 0xff));
+	return 0 == _TwoWireInstance->endTransmission(true);
 }
 
 uint16_t AC101::ReadReg(uint8_t reg)
 {
-	_TwoWireInstance.beginTransmission(AC101_ADDR);
-	_TwoWireInstance.write(reg);
-	_TwoWireInstance.endTransmission(false);
+	_TwoWireInstance->beginTransmission(AC101_ADDR);
+	_TwoWireInstance->write(reg);
+	_TwoWireInstance->endTransmission(false);
 
 	uint16_t val = 0u;
-	if (2 == _TwoWireInstance.requestFrom(uint16_t(AC101_ADDR), uint8_t(2), true))
+	if (2 == _TwoWireInstance->requestFrom(uint16_t(AC101_ADDR), uint8_t(2), true))
 	{
-		val = uint16_t(_TwoWireInstance.read() << 8) + uint16_t(_TwoWireInstance.read());
+		val = uint16_t(_TwoWireInstance->read() << 8) + uint16_t(_TwoWireInstance->read());
 	}
-	_TwoWireInstance.endTransmission(false);
+	_TwoWireInstance->endTransmission(false);
 
 	return val;
 }
 
-AC101::AC101( TwoWire & TwoWireInstance ) : _TwoWireInstance(TwoWireInstance)
+AC101::AC101( TwoWire *TwoWireInstance)
 {
+	_TwoWireInstance = TwoWireInstance;
 }
 
 bool AC101::begin()

--- a/src/AC101.cpp
+++ b/src/AC101.cpp
@@ -166,6 +166,8 @@ AC101::AC101( TwoWire & TwoWireInstance ) : _TwoWireInstance(TwoWireInstance)
 
 bool AC101::begin()
 {
+	bool ok = true;
+	
 	// Reset all registers, readback default as sanity check
 	ok &= WriteReg(CHIP_AUDIO_RS, 0x123);
 	delay(100);

--- a/src/AC101.h
+++ b/src/AC101.h
@@ -95,7 +95,7 @@ public:
 	} Mode_t;
 
 	// Constructor.
-  	AC101(TwoWire & TwoWireInstance = Wire);
+  	AC101(TwoWire *TwoWireInstance = &Wire);
 
 	// Initialize codec, using provided I2C pins and bus frequency.
 	// @return True on success, false on failure.
@@ -159,7 +159,7 @@ protected:
 	bool WriteReg(uint8_t reg, uint16_t val);
 	uint16_t ReadReg(uint8_t reg);
 private:
-	TwoWire & _TwoWireInstance;	// TwoWire Instance
+	TwoWire *_TwoWireInstance = NULL;	// TwoWire Instance
 };
 
 #endif

--- a/src/AC101.h
+++ b/src/AC101.h
@@ -94,11 +94,11 @@ public:
 	} Mode_t;
 
 	// Constructor.
-  	AC101();
+  	AC101(TwoWire & TwoWireInstance = Wire);
 
 	// Initialize codec, using provided I2C pins and bus frequency.
 	// @return True on success, false on failure.
-	bool begin(int sda = -1, int scl = -1, uint32_t frequency = 400000);
+	bool begin();
 
 	// Get speaker volume.
 	// @return Speaker volume, [63..0] for [0..-43.5] [dB], in increments of 2.

--- a/src/AC101.h
+++ b/src/AC101.h
@@ -23,6 +23,7 @@
 #define AC101_H
 
 #include <inttypes.h>
+#include <Wire.h>
 
 class AC101
 {
@@ -157,6 +158,8 @@ public:
 protected:
 	bool WriteReg(uint8_t reg, uint16_t val);
 	uint16_t ReadReg(uint8_t reg);
+private:
+	TwoWire & _TwoWireInstance;	// TwoWire Instance
 };
 
 #endif


### PR DESCRIPTION
I implemented the use of TwoWire otherwise it was not possible for me to use a second I2C-Bus on the ESP32-A1S

I dont have too much experience in Arduino programming, but isn't it Best-Practice to leave such reusable components external?