### PR TITLE
Fix headphone output not always working.

### DIFF
--- a/src/AC101.cpp
+++ b/src/AC101.cpp
@@ -315,8 +315,6 @@ bool AC101::SetMode(Mode_t mode)
 	{
 		// Enable Headphone output
 		ok &= WriteReg(OMIXER_DACA_CTRL, 0xff80);
-		ok &= WriteReg(HPOUT_CTRL, 0xc3c1);	
-		ok &= WriteReg(HPOUT_CTRL, 0xcb00);
 		delay(100);
 		ok &= WriteReg(HPOUT_CTRL, 0xfbc0);
 		ok &= SetVolumeHeadphone(30);


### PR DESCRIPTION
I found that when using the ESP32 Audiokit with an ESP32-A1S based on the AC101 that often the headphone output was not working (i.e. no output could be heared). Speaker output was always working. Based on the linux driver source code found here: https://gitee.com/wu_yumin/seeed-voicecard/blob/master/ac101.c#L622 I added the delay right after the OMIXER_DACA_CTRL change. That works like a charm. Then I removed the two first writes to HPOUT_CTRL as they are overwritten and should not have any effect anyways. Still everything is working as expected.